### PR TITLE
add checks to support n32 ABI for mips64

### DIFF
--- a/src/atomic_ops/sysdeps/gcc/mips.h
+++ b/src/atomic_ops/sysdeps/gcc/mips.h
@@ -24,7 +24,7 @@
 /* Data dependence does not imply read ordering.  */
 #define AO_NO_DD_ORDERING
 
-#ifdef __mips64
+#if defined(__mips64) && (_MIPS_SIM == _ABI64)
 # define AO_MIPS_SET_ISA    "       .set mips3\n"
 # define AO_MIPS_LL_1(args) "       lld " args "\n"
 # define AO_MIPS_SC(args)   "       scd " args "\n"


### PR DESCRIPTION
The existing preprocessor checks for mips64 support do not account for the n32 ABI.  When building with "gcc -mabi=n32", test_atomic and test_stack both fail, and test_malloc appears to hang indefinitely while spinning at 100% across ten cores.

With this change, the ABI is also checked via _MIPS_SIM.  This is tested on Octeon II CN6880, built with gcc 4.7.0 using both -mabi=64 and -mabi=n32.