### PR TITLE
gcc 5.x compatibility for aarch64 ops

### DIFF
--- a/src/atomic_ops/sysdeps/gcc/aarch64.h
+++ b/src/atomic_ops/sysdeps/gcc/aarch64.h
@@ -30,7 +30,7 @@
 #endif
 
 /* TODO: Adjust version check on fixing double-wide AO support in GCC. */
-#if __GNUC__ == 4
+#if __GNUC__ >= 4
 
   AO_INLINE AO_double_t
   AO_double_load(const volatile AO_double_t *addr)
@@ -195,6 +195,6 @@
     return !result;
   }
 # define AO_HAVE_double_compare_and_swap_full
-#endif /* __GNUC__ == 4 */
+#endif /* __GNUC__ >= 4 */
 
 #include "generic.h"


### PR DESCRIPTION
Small change to make aarch64 support work with gcc 5.x.  Otherwise it demands gcc -latomic and still fails test_stack .