### PR TITLE
Detect AIX on powerpc using gcc

### DIFF
--- a/src/atomic_ops.h
+++ b/src/atomic_ops.h
@@ -266,7 +266,8 @@
 #   include "atomic_ops/sysdeps/gcc/nios2.h"
 # endif /* __nios2__ */
 # if defined(__powerpc__) || defined(__ppc__) || defined(__PPC__) \
-     || defined(__powerpc64__) || defined(__ppc64__)
+     || defined(__powerpc64__) || defined(__ppc64__) \
+     || defined(_ARCH_PPC)
 #   include "atomic_ops/sysdeps/gcc/powerpc.h"
 # endif /* __powerpc__ */
 # if defined(__aarch64__)


### PR DESCRIPTION
gcc does not define any of: \_\_powerpc__, \_\_ppc__, \_\_PPC__, \_\_powerpc64__, \_\_ppc64__.
But it does define _ARCH_PPC and _POWER, I chosed to use _ARCH_PPC because it is
more clear.

gcc -v:
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/home/0/freeware/bin/../libexec/gcc/powerpc-ibm-aix7.1.0.0/4.6.3/lto-wrapper
Target: powerpc-ibm-aix7.1.0.0
Configured with: ../gcc-4.6.3/configure --with-as=/usr/bin/as --with-ld=/usr/bin/ld --enable-languages=c,c++,fortran --prefix=/opt/freeware --mandir=/opt/freeware/man --infodir=/opt/freeware/info --enable-threads --enable-version-specific-runtime-libs --disable-nls --enable-decimal-float=dpd --host=powerpc-ibm-aix7.1.0.0
Thread model: aix
gcc version 4.6.3 (GCC)