### PR TITLE
Fix #15 test_stack failed on POWER7

### DIFF
--- a/src/atomic_ops/sysdeps/gcc/powerpc.h
+++ b/src/atomic_ops/sysdeps/gcc/powerpc.h
@@ -27,8 +27,6 @@
 /* uncached memory, which we don't support.  It does not order loads    */
 /* from cached memory.                                                  */
 
-#include "../all_aligned_atomic_load_store.h"
-
 #include "../test_and_set_t_is_ao_t.h"
         /* There seems to be no byte equivalent of lwarx, so this       */
         /* may really be what we want, at least in the 32-bit case.     */

--- a/src/atomic_ops/sysdeps/ibmc/powerpc.h
+++ b/src/atomic_ops/sysdeps/ibmc/powerpc.h
@@ -13,8 +13,6 @@
 /* Thanks to Maged Michael, Doug Lea, and Roger Hoover for helping to   */
 /* track some of this down and correcting my misunderstandings. -HB     */
 
-#include "../all_aligned_atomic_load_store.h"
-
 #include "../test_and_set_t_is_ao_t.h"
 
 void AO_sync(void);


### PR DESCRIPTION
AO_load is not mapped to AO_load_acquire due
to the inclusion of all_aligned_atomic_load_store.h