### PR TITLE
Correct spelling of references to ARMv6KZ

### DIFF
--- a/src/atomic_ops/sysdeps/gcc/arm.h
+++ b/src/atomic_ops/sysdeps/gcc/arm.h
@@ -73,7 +73,8 @@
 # if !defined(__ARM_ARCH_6__) && !defined(__ARM_ARCH_6J__) \
      && !defined(__ARM_ARCH_6T2__) && !defined(__ARM_ARCH_6Z__) \
      && !defined(__ARM_ARCH_6ZT2__)
-#   if !defined(__ARM_ARCH_6K__) && !defined(__ARM_ARCH_6ZK__)
+#   if !defined(__ARM_ARCH_6K__) && !defined(__ARM_ARCH_6KZ__) \
+     && !defined(__ARM_ARCH_6ZK__)
       /* DMB is present in ARMv6M and ARMv7+.   */
 #     define AO_ARM_HAVE_DMB
 #   endif


### PR DESCRIPTION
Hi,

Due to a misspelling in GCC [1] the check for the ARMv6KZ platform
uses ARM_ARCH_6ZK instead of ARM_ARCH_6KZ, this cause breakage on FreeBSD armv6 (we use clang as a compiler).
Relevant PR on FreeBSD side:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=208176

[1] https://gcc.gnu.org/ml/gcc-patches/2015-06/msg01679.html

Thanks in advance.