### PR TITLE
Fix gcc x86 AO_compare_double_and_swap_double missing side effect

### DIFF
--- a/src/atomic_ops/sysdeps/gcc/x86.h
+++ b/src/atomic_ops/sysdeps/gcc/x86.h
@@ -443,6 +443,7 @@ AO_fetch_compare_and_swap_full(volatile AO_t *addr, AO_t old_val,
                                          AO_t new_val1, AO_t new_val2)
   {
     char result;
+    AO_t scratch_reg;
 #   ifdef __PIC__
       AO_t saved_ebx;
 
@@ -457,14 +458,15 @@ AO_fetch_compare_and_swap_full(volatile AO_t *addr, AO_t old_val,
 #     ifdef __OPTIMIZE__
         __asm__ __volatile__("mov %%ebx, %2\n\t" /* save ebx */
                              "lea %0, %%edi\n\t" /* in case addr is in ebx */
-                             "mov %7, %%ebx\n\t" /* load new_val1 */
+                             "mov %8, %%ebx\n\t" /* load new_val1 */
                              "lock; cmpxchg8b (%%edi)\n\t"
                              "mov %2, %%ebx\n\t" /* restore ebx */
                              "setz %1"
-                        : "=m" (*addr), "=a" (result), "=m" (saved_ebx)
-                        : "m" (*addr), "d" (old_val2), "a" (old_val1),
-                          "c" (new_val2), "m" (new_val1)
-                        : "%edi", "memory");
+			     : "=m" (*addr), "=a" (result),
+			       "=m" (saved_ebx), "=d" (scratch_reg)
+			     : "m" (*addr), "d" (old_val2), "a" (old_val1),
+			       "c" (new_val2), "m" (new_val1)
+			     : "%edi", "memory");
 #     else
         /* A less-efficient code manually preserving edi if GCC invoked */
         /* with -O0 option (otherwise it fails while finding a register */
@@ -473,13 +475,13 @@ AO_fetch_compare_and_swap_full(volatile AO_t *addr, AO_t old_val,
         __asm__ __volatile__("mov %%edi, %3\n\t" /* save edi */
                              "mov %%ebx, %2\n\t" /* save ebx */
                              "lea %0, %%edi\n\t" /* in case addr is in ebx */
-                             "mov %8, %%ebx\n\t" /* load new_val1 */
+                             "mov %9, %%ebx\n\t" /* load new_val1 */
                              "lock; cmpxchg8b (%%edi)\n\t"
                              "mov %2, %%ebx\n\t" /* restore ebx */
                              "mov %3, %%edi\n\t" /* restore edi */
                              "setz %1"
                         : "=m" (*addr), "=a" (result),
-                          "=m" (saved_ebx), "=m" (saved_edi)
+                          "=m" (saved_ebx), "=m" (saved_edi), "=d" (scratch_reg)
                         : "m" (*addr), "d" (old_val2), "a" (old_val1),
                           "c" (new_val2), "m" (new_val1) : "memory");
 #     endif
@@ -488,10 +490,10 @@ AO_fetch_compare_and_swap_full(volatile AO_t *addr, AO_t old_val,
       /* faster) by using ebx as new_val1 (GCC would refuse to compile  */
       /* such code for PIC mode).                                       */
       __asm__ __volatile__ ("lock; cmpxchg8b %0; setz %1"
-                        : "=m" (*addr), "=a" (result)
-                        : "m" (*addr), "d" (old_val2), "a" (old_val1),
-                          "c" (new_val2), "b" (new_val1)
-                        : "memory");
+			    : "=m" (*addr), "=a" (result), "=d" (scratch_reg)
+			    : "m" (*addr), "d" (old_val2), "a" (old_val1),
+			      "c" (new_val2), "b" (new_val1)
+			    : "memory");
 #   endif
     return (int) result;
   }
@@ -553,11 +555,12 @@ AO_fetch_compare_and_swap_full(volatile AO_t *addr, AO_t old_val,
                                          AO_t new_val1, AO_t new_val2)
   {
     char result;
+    AO_t scratch_reg;
     __asm__ __volatile__("lock; cmpxchg16b %0; setz %1"
-                        : "=m"(*addr), "=a"(result)
-                        : "m"(*addr), "d" (old_val2), "a" (old_val1),
-                          "c" (new_val2), "b" (new_val1)
-                        : "memory");
+			 : "=m" (*addr), "=a"(result), "=d" (scratch_reg)
+			 : "m" (*addr), "d" (old_val2), "a" (old_val1),
+			   "c" (new_val2), "b" (new_val1)
+			 : "memory");
     return (int) result;
   }
 # define AO_HAVE_compare_double_and_swap_double_full


### PR DESCRIPTION
Fix #41.