### PR TITLE
Add basic ARC support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -81,6 +81,7 @@ nobase_private_HEADERS = atomic_ops/ao_version.h \
         \
           atomic_ops/sysdeps/gcc/aarch64.h \
           atomic_ops/sysdeps/gcc/alpha.h \
+          atomic_ops/sysdeps/gcc/arc.h \
           atomic_ops/sysdeps/gcc/arm.h \
           atomic_ops/sysdeps/gcc/avr32.h \
           atomic_ops/sysdeps/gcc/cris.h \

--- a/src/atomic_ops.h
+++ b/src/atomic_ops.h
@@ -337,6 +337,8 @@
 #   include "atomic_ops/sysdeps/gcc/riscv.h"
 # elif defined(__tile__)
 #   include "atomic_ops/sysdeps/gcc/tile.h"
+# elif defined(__arc__)
+#   include "atomic_ops/sysdeps/gcc/arc.h"
 # else /* etc. */
 #   include "atomic_ops/sysdeps/gcc/generic.h"
 # endif

--- a/src/atomic_ops/sysdeps/gcc/arc.h
+++ b/src/atomic_ops/sysdeps/gcc/arc.h
@@ -1,0 +1,12 @@
+/*
+ * THIS MATERIAL IS PROVIDED AS IS, WITH ABSOLUTELY NO WARRANTY EXPRESSED
+ * OR IMPLIED.  ANY USE IS AT YOUR OWN RISK.
+ *
+ * Permission is hereby granted to use or copy this program
+ * for any purpose,  provided the above notices are retained on all copies.
+ * Permission to modify the code and to distribute modified code is granted,
+ * provided the above notices are retained, and a notice that the code was
+ * modified is included with the above copyright notice.
+ */
+
+#include "generic.h"


### PR DESCRIPTION
Basic support, verfied with make check on target

| /home/root/libatomic_ops>uname -a
| Linux hsdk 5.9.0-rc1-00006-g8f20d5e3b890 #132 SMP PREEMPT Tue Aug 25 14:33:13 PDT 2020 arc arc arc GNU/Linux
| /home/root/libatomic_ops>make check
| ...
| PASS: test_atomic
| PASS: test_atomic_generalized
| PASS: test_stack
| PASS: test_malloc
| PASS: test_atomic_pthreads
| ============================================================================
| Testsuite summary for libatomic_ops 7.7.0
| ============================================================================
| # TOTAL: 5
| # PASS:  5
| # SKIP:  0
| # XFAIL: 0
| # FAIL:  0
| # XPASS: 0
| # ERROR: 0
| ============================================================================
|

Signed-off-by: Vineet Gupta <vgupta@synopsys.com>